### PR TITLE
added GTSAM_INCLUDE_DIR

### DIFF
--- a/mincurves/CMakeLists.txt
+++ b/mincurves/CMakeLists.txt
@@ -5,6 +5,8 @@ find_package(catkin_simple 0.1.0 REQUIRED)
 
 catkin_simple(ALL_DEPS_REQUIRED)
 
+include_directories(${GTSAM_INCLUDE_DIR})
+
 cs_add_library(${PROJECT_NAME} 
   src/SE3Curve.cpp
   src/DiscreteSE3Curve.cpp


### PR DESCRIPTION
Building on 16.04/Kinetic fails with a complaint that Manifold.h of the gtsam library is not found. Explicitly adding the GTSAM_INCLUDE_DIR made it work for me. The same patch was also used here: 

https://github.com/ethz-asl/minkindr_gtsam/blob/master/minkindr_gtsam/CMakeLists.txt